### PR TITLE
Provide override for JSON seralization and updated pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/java/org/ohdsi/analysis/Utils.java
+++ b/src/main/java/org/ohdsi/analysis/Utils.java
@@ -3,6 +3,7 @@ package org.ohdsi.analysis;
 import static com.fasterxml.jackson.core.util.DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -20,6 +21,10 @@ import java.util.function.Function;
 public class Utils {
 
     private static ObjectMapper getObjectMapper() {
+        return getObjectMapper(JsonInclude.Include.NON_NULL);
+    }
+    
+    private static ObjectMapper getObjectMapper(Include serializationInclusion) {
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.disable(
@@ -34,7 +39,7 @@ public class Utils {
 
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setSerializationInclusion(serializationInclusion);
 
         return objectMapper;
     }
@@ -63,6 +68,23 @@ public class Utils {
 
         try {
             ObjectMapper objectMapper = getObjectMapper();
+            return Utils.serialize(object, objectMapper);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    public static String serialize(Object object, Include serializationInclusion) {
+        try {
+            ObjectMapper objectMapper = getObjectMapper(serializationInclusion);
+            return Utils.serialize(object, objectMapper);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    private static String serialize(Object object, ObjectMapper objectMapper) {
+        try {
             return objectMapper.writeValueAsString(object);
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/org/ohdsi/analysis/Utils.java
+++ b/src/main/java/org/ohdsi/analysis/Utils.java
@@ -3,7 +3,6 @@ package org.ohdsi.analysis;
 import static com.fasterxml.jackson.core.util.DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -21,10 +20,6 @@ import java.util.function.Function;
 public class Utils {
 
     private static ObjectMapper getObjectMapper() {
-        return getObjectMapper(JsonInclude.Include.NON_NULL);
-    }
-    
-    private static ObjectMapper getObjectMapper(Include serializationInclusion) {
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.disable(
@@ -39,7 +34,7 @@ public class Utils {
 
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-        objectMapper.setSerializationInclusion(serializationInclusion);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         return objectMapper;
     }
@@ -68,23 +63,6 @@ public class Utils {
 
         try {
             ObjectMapper objectMapper = getObjectMapper();
-            return Utils.serialize(object, objectMapper);
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-    
-    public static String serialize(Object object, Include serializationInclusion) {
-        try {
-            ObjectMapper objectMapper = getObjectMapper(serializationInclusion);
-            return Utils.serialize(object, objectMapper);
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-    
-    private static String serialize(Object object, ObjectMapper objectMapper) {
-        try {
             return objectMapper.writeValueAsString(object);
         } catch (Exception ex) {
             throw new RuntimeException(ex);


### PR DESCRIPTION
Added overload for serialization when we need to explicitly set the JSON serialization strategy. This is required for PLE/PLP serialization whereby we need to include elements that have a NULL value for use by Hydra and in R.

Adding this functionality to the SAA Utils will allow us to remove these work-arounds in WebAPI:

https://github.com/OHDSI/WebAPI/blob/master/src/main/java/org/ohdsi/webapi/service/EstimationService.java#L294

https://github.com/OHDSI/WebAPI/blob/master/src/main/java/org/ohdsi/webapi/service/PredictionService.java#L249

Also, I added an explicit version for `org.apache.maven.plugins` since I received this warning when compiling:

> Some problems were encountered while building the effective model for org.ohdsi:standardized-analysis-api:jar:1.0.0-SNAPSHOT
> 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 12, column 21
> 
> It is highly recommended to fix these problems because they threaten the stability of your build.
> 
> For this reason, future Maven versions might no longer support building such malformed projects.

Also, before merging in this PR, I'd recommend that you tag the current version on master to note this as v1.0.0 and then we can increment to v1.0.1 barring any feedback/changes to this code.

Related to OHDSI/Atlas#988