### PR TITLE
Update includedCovariateIds to use Long instead of Integer

### DIFF
--- a/src/main/java/org/ohdsi/analysis/featureextraction/design/CovariateSettings.java
+++ b/src/main/java/org/ohdsi/analysis/featureextraction/design/CovariateSettings.java
@@ -806,7 +806,7 @@ public interface CovariateSettings extends RLangClass {
      * @return
      */
     @JsonGetter("includedCovariateIds")
-    List<Integer> getIncludedCovariateIds();
+    List<Long> getIncludedCovariateIds();
 
     /**
      *

--- a/src/test/java/org/ohdsi/analysis/BaseTest.java
+++ b/src/test/java/org/ohdsi/analysis/BaseTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.ohdsi.analysis.cyclops.design.AlgorithmTypeEnum;
@@ -32,6 +33,10 @@ import org.ohdsi.circe.vocabulary.ConceptSetExpression;
  * Base test
  */
 public class BaseTest {
+    
+    private static final Long[] includedCovariateIds = new Long[]{
+        4206591215L
+    };
 
     /**
      * This will create a cohort for with a default name and ID
@@ -728,8 +733,8 @@ public class BaseTest {
             }
 
             @Override
-            public List<Integer> getIncludedCovariateIds() {
-                return new ArrayList<>();
+            public List<Long> getIncludedCovariateIds() {
+                return new ArrayList<>(Arrays.asList(includedCovariateIds));
             }
 
             @Override

--- a/src/test/resources/analysis/CovariateSettings.json
+++ b/src/test/resources/analysis/CovariateSettings.json
@@ -113,7 +113,7 @@
         "addDescendantsToInclude": false,
         "excludedCovariateConceptIds": [],
         "addDescendantsToExclude": false,
-        "includedCovariateIds": [],
+        "includedCovariateIds": [4206591215],
         "attr_fun": "getDbDefaultCovariateData",
         "attr_class": "covariateSettings"
     }

--- a/src/test/resources/estimation/ComparativeCohortAnalysis.json
+++ b/src/test/resources/estimation/ComparativeCohortAnalysis.json
@@ -381,7 +381,7 @@
 			"addDescendantsToInclude": false,
 			"excludedCovariateConceptIds": [],
 			"addDescendantsToExclude": false,
-			"includedCovariateIds": [],
+			"includedCovariateIds": [4206591215],
 			"attr_fun": "getDbDefaultCovariateData",
 			"attr_class": "covariateSettings"
 		},
@@ -576,7 +576,7 @@
 							"addDescendantsToInclude": false,
 							"excludedCovariateConceptIds": [],
 							"addDescendantsToExclude": false,
-							"includedCovariateIds": [],
+							"includedCovariateIds": [4206591215],
 							"attr_fun": "getDbDefaultCovariateData",
 							"attr_class": "covariateSettings"
 						},

--- a/src/test/resources/prediction/PatientLevelPredictionAnalysis.json
+++ b/src/test/resources/prediction/PatientLevelPredictionAnalysis.json
@@ -285,7 +285,7 @@
             "addDescendantsToInclude": false,
             "excludedCovariateConceptIds": [],
             "addDescendantsToExclude": false,
-            "includedCovariateIds": [],
+            "includedCovariateIds": [4206591215],
             "attr_fun": "getDbDefaultCovariateData",
             "attr_class": "covariateSettings"
         }


### PR DESCRIPTION
Required to fix OHDSI/WebAPI#932. Changed `includedCovariateIds` to accept an ArrayList<Long> to handle the case when covariate IDs are > than the maximum integer value allowed by Java. Updated test cases to include this check as well.