### PR TITLE
Fixes repository url issue

### DIFF
--- a/standardized-analysis-specs/pom.xml
+++ b/standardized-analysis-specs/pom.xml
@@ -24,11 +24,6 @@
 
     <repositories>
         <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2/</url>
-        </repository>
-        <repository>
             <id>ohdsi</id>
             <name>repo.ohdsi.org</name>
             <url>http://repo.ohdsi.org:8085/nexus/content/repositories/releases</url>

--- a/standardized-analysis-utils/pom.xml
+++ b/standardized-analysis-utils/pom.xml
@@ -27,11 +27,6 @@
 
     <repositories>
         <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2/</url>
-        </repository>
-        <repository>
             <id>ohdsi</id>
             <name>repo.ohdsi.org</name>
             <url>http://repo.ohdsi.org:8085/nexus/content/repositories/releases</url>


### PR DESCRIPTION
removes http://repo.maven.apache.org/maven2 from pom
http is no longer supported by maven central. Default repo points to the correct https version
https://stackoverflow.com/a/59764670/11676