### PR TITLE
Always include packageName for Hydra study packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,25 +24,9 @@
 
     <repositories>
         <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2/</url>
-        </repository>
-        <repository>
             <id>ohdsi</id>
             <name>repo.ohdsi.org</name>
-            <url>http://repo.ohdsi.org:8085/nexus/content/repositories/releases</url>
-        </repository>
-        <repository>
-            <id>ohdsi.snapshots</id>
-            <name>repo.ohdsi.org-snapshots</name>
-            <url>http://repo.ohdsi.org:8085/nexus/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
+            <url>http://repo.ohdsi.org:8085/nexus/content/groups/public</url>
         </repository>
     </repositories>
     <dependencies>

--- a/src/main/java/org/ohdsi/analysis/StudyPackage.java
+++ b/src/main/java/org/ohdsi/analysis/StudyPackage.java
@@ -1,0 +1,16 @@
+package org.ohdsi.analysis;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public interface StudyPackage {
+    /**
+     * The name of the R Package for execution
+     *
+     * @return packageName
+     *
+     */
+    @JsonGetter(value = "packageName")
+    @JsonInclude
+    String getPackageName();
+}

--- a/src/main/java/org/ohdsi/analysis/estimation/design/EstimationAnalysis.java
+++ b/src/main/java/org/ohdsi/analysis/estimation/design/EstimationAnalysis.java
@@ -5,12 +5,13 @@ import java.util.Collection;
 import org.ohdsi.analysis.Cohort;
 import org.ohdsi.analysis.ConceptSetCrossReference;
 import org.ohdsi.analysis.hydra.design.SkeletonTypeEnum;
+import org.ohdsi.analysis.StudyPackage;
 
 /**
  *
  * @author Anthony Sena <https://github.com/anthonysena>
  */
-public interface EstimationAnalysis {
+public interface EstimationAnalysis extends StudyPackage {
 
     /**
      * Get cohortDefinitions
@@ -149,15 +150,6 @@ public interface EstimationAnalysis {
      */
     @JsonGetter(value = "organizationName")
     String getOrganizationName();
-
-    /**
-     * The name of the R Package for execution
-     *
-     * @return packageName
-     *
-     */
-    @JsonGetter(value = "packageName")
-    String getPackageName();
 
     /**
      * Get doPositiveControlSynthesis

--- a/src/main/java/org/ohdsi/analysis/prediction/design/PatientLevelPredictionAnalysis.java
+++ b/src/main/java/org/ohdsi/analysis/prediction/design/PatientLevelPredictionAnalysis.java
@@ -7,12 +7,13 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import java.math.BigDecimal;
 import java.util.Collection;
 import org.ohdsi.analysis.Cohort;
+import org.ohdsi.analysis.StudyPackage;
 
 /**
  *
  * @author Anthony Sena <https://github.com/anthonysena>
  */
-public interface PatientLevelPredictionAnalysis {
+public interface PatientLevelPredictionAnalysis extends StudyPackage {
 
     /**
      *
@@ -48,13 +49,6 @@ public interface PatientLevelPredictionAnalysis {
      */
     @JsonGetter("organizationName")
     String getOrganizationName();
-
-    /**
-     *
-     * @return
-     */
-    @JsonGetter("packageName")
-    String getPackageName();
 
     /**
      *


### PR DESCRIPTION
Per OHDSI/WebAPI#1761, refactoring the Estimation & Prediction designs to ensure that the attribute `packageName` is always included to ensure Hydra works when hydrating a design exported from Atlas/WebAPI.

Unrelated to these changes, I modified the pom.xml since I was unable to obtain dependencies from maven central via http. I've revised the pom.xml to reflect the same configuration present in WebAPI for consistency. 